### PR TITLE
Fix security vulnerability with qs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "urlencoded"
   ],
   "dependencies": {
-    "qs": "~0.6.6",
+    "qs": "~1.0.0",
     "raw-body": "~1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
There is a security vulnerability with qs,

https://nodesecurity.io/advisories/qs_dos_memory_exhaustion

https://nodesecurity.io/advisories/qs_dos_extended_event_loop_blocking

Please use the most recent version of qs.
