### PR TITLE
Fix content-length zero should not parse json

### DIFF
--- a/lib/json.js
+++ b/lib/json.js
@@ -28,6 +28,8 @@ module.exports = function(req, opts){
   opts.limit = opts.limit || '1mb';
 
   return function(done){
+    if (+len === 0) return done(null, null);
+
     raw(req, opts, function(err, str){
       if (err) return done(err);
 

--- a/test/json.js
+++ b/test/json.js
@@ -20,4 +20,21 @@ describe('parse.json(req, opts)', function(){
       .end(function(){});
     })
   })
+
+  describe('with content-length zero', function(){
+    it('should return null', function(done) {
+      var app = koa();
+
+      app.use(function *() {
+        var body = yield parse.json(this);
+        (null === body).should.be.true;
+        done();
+      });
+
+      request(app.listen())
+      .post('/')
+      .set('content-length', 0)
+      .end(function(){});
+    })
+  })
 })


### PR DESCRIPTION
This PR fixes an issue where a *POST* request with a header of `Content-Length: 0` and no body will return an *HTTP 400* error.

According to [RFC2730 Section 3.3.2](http://tools.ietf.org/html/rfc7230#section-3.3.2):

> "For example, a Content-Length header field is normally sent in a POST request even when the value is 0
> (indicating an empty payload body)."

I experienced this issue using the [Guzzle](https://github.com/guzzle/guzzle) PHP framework which sends a "Content-Length: 0" header even when *POST*ing without a body but it has also been reported with jQuery clients.

I have also found that cURL makes the same assumption. For example:

```bash
curl http://localhost:3000/ -H 'accept: application/json' -d ''
```

This will cause cURL to add a `Content-Length: 0` header and ultimately trigger an *HTTP 400* response.

The issue has also been [discussed](https://github.com/jshttp/type-is/issues/9) on the *type-is* project where @jonathanong mentioned that parsers will need to check if the body is empty. (which is what this PR implements)

Additionally, express' body-parser package has also addressed this issue by always [returning an empty object](https://github.com/expressjs/body-parser/blob/master/lib/types/json.js#L62-L66).

I personally believe that returning `null` is more appropriate since it makes no assumptions on the client, i.e.: why not return an empty array? or an empty string with double-quotes? all are equally valid JSON.