### PR TITLE
Enable setting options for qs when parsing form data and query strings.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,6 +30,7 @@ $ npm install co-body
 
   - `limit` number or string representing the request size limit (1mb for json and 56kb for form-urlencoded)
   - `strict` when set to `true`, JSON parser will only accept arrays and objects; when `false` will accept anything `JSON.parse` accepts. Defaults to `true`. (also `strict` mode will always return object).
+  - `queryString` an object of options when parsing query strings and form data. See [qs](https://github.com/hapijs/qs) for more information.
 
 more options available via [raw-body](https://github.com/stream-utils/raw-body#getrawbodystream-options-callback):
 

--- a/lib/form.js
+++ b/lib/form.js
@@ -33,7 +33,7 @@ module.exports = function(req, opts){
       if (err) return done(err);
 
       try {
-        done(null, qs.parse(str));
+        done(null, qs.parse(str, opts.queryString));
       } catch (err) {
         err.status = 400;
         err.body = str;

--- a/package.json
+++ b/package.json
@@ -13,15 +13,15 @@
     "urlencoded"
   ],
   "dependencies": {
-    "qs": "~2.4.1",
-    "raw-body": "~1.3.4"
+    "qs": "~4.0.0",
+    "raw-body": "~2.1.2"
   },
   "devDependencies": {
-    "istanbul-harmony": "~0.3.12",
-    "koa": "~0.20.0",
+    "istanbul-harmony": "~0.3.16",
+    "koa": "~0.21.0",
     "mocha": "*",
     "should": "*",
-    "supertest": "~0.8.2"
+    "supertest": "~1.0.1"
   },
   "license": "MIT",
   "scripts": {

--- a/test/form.js
+++ b/test/form.js
@@ -11,14 +11,51 @@ describe('parse.form(req, opts)', function(){
       app.use(function *(){
         var body = yield parse.form(this);
         body.foo.bar.should.equal('baz');
-        done();
+        this.status = 200;
       });
 
       request(app.listen())
       .post('/')
       .type('form')
       .send({ foo: { bar: 'baz' }})
-      .end(function(){});
+      .end(function(err){ done(err); });
+    })
+  })
+
+  describe('with qs settings', function(){
+    var data = { level1: { level2: { level3: { level4: { level5: { level6: { level7: 'Hello' } } } } } } };
+
+    it('should not parse full depth', function(done){
+      var app = koa();
+
+      app.use(function *(){
+        var body = yield parse.form(this);  // default to depth = 5
+        body.level1.level2.level3.level4.level5.level6['[level7]'].should.equal('Hello');
+        this.status = 200;
+      });
+
+      request(app.listen())
+      .post('/')
+      .type('form')
+      .send({ level1: { level2: { level3: { level4: { level5: { level6: { level7: 'Hello' }}}}}}})
+      .end(function(err){ done(err); });
+
+    })
+
+    it('should parse', function(done){
+      var app = koa();
+
+      app.use(function *(){
+        var body = yield parse.form(this, { queryString: { depth: 10 } });
+        body.level1.level2.level3.level4.level5.level6.level7.should.equal('Hello');
+        this.status = 200;
+      });
+
+      request(app.listen())
+      .post('/')
+      .type('form')
+      .send(data)
+      .end(function(err){ done(err); });
     })
   })
 })


### PR DESCRIPTION
Updated dependencies. Added qs options support via queryString options key. This fixes the issue #24 