### PR TITLE
Use Promises instead of thunks

### DIFF
--- a/lib/any.js
+++ b/lib/any.js
@@ -3,17 +3,17 @@
  * Module dependencies.
  */
 
-var typeis = require('type-is')
+var typeis = require('type-is');
 var json = require('./json');
 var form = require('./form');
 var text = require('./text');
 
 var jsonTypes = ['json', 'application/*+json', 'application/csp-report'];
-var formTypes = ['urlencoded']
-var textTypes = ['text']
+var formTypes = ['urlencoded'];
+var textTypes = ['text'];
 
 /**
- * Return a a thunk which parses form and json requests
+ * Return a Promise which parses form and json requests
  * depending on the Content-Type.
  *
  * Pass a node request or an object with `.req`,
@@ -42,11 +42,9 @@ module.exports = function(req, opts){
   if (typeis(req, textType)) return text(req, opts);
 
   // invalid
-  return function(done){
-    var type = req.headers['content-type'] || '';
-    var message = type ? 'Unsupported content-type: ' + type : 'Missing content-type';
-    var err = new Error(message);
-    err.status = 415;
-    done(err);
-  };
+  var type = req.headers['content-type'] || '';
+  var message = type ? 'Unsupported content-type: ' + type : 'Missing content-type';
+  var err = new Error(message);
+  err.status = 415;
+  return Promise.reject(err);
 };

--- a/lib/form.js
+++ b/lib/form.js
@@ -7,7 +7,7 @@ var raw = require('raw-body');
 var qs = require('qs');
 
 /**
- * Return a a thunk which parses x-www-form-urlencoded requests.
+ * Return a Promise which parses x-www-form-urlencoded requests.
  *
  * Pass a node request or an object with `.req`,
  * such as a koa Context.
@@ -28,17 +28,15 @@ module.exports = function(req, opts){
   opts.encoding = opts.encoding || 'utf8';
   opts.limit = opts.limit || '56kb';
 
-  return function(done){
-    raw(req, opts, function(err, str){
-      if (err) return done(err);
-
+  // raw-body returns a Promise when no callback is specified
+  return raw(req, opts)
+    .then(function(str){
       try {
-        done(null, qs.parse(str, opts.queryString));
+        return qs.parse(str, opts.queryString);
       } catch (err) {
         err.status = 400;
         err.body = str;
-        done(err);
+        throw err;
       }
     });
-  }
 };

--- a/lib/json.js
+++ b/lib/json.js
@@ -10,7 +10,7 @@ var raw = require('raw-body');
 var strictJSONReg = /^[\x20\x09\x0a\x0d]*(\[|\{)/;
 
 /**
- * Return a a thunk which parses json requests.
+ * Return a Promise which parses json requests.
  *
  * Pass a node request or an object with `.req`,
  * such as a koa Context.
@@ -32,20 +32,17 @@ module.exports = function(req, opts){
   opts.limit = opts.limit || '1mb';
   var strict = opts.strict !== false;
 
-  return function(done){
-    raw(req, opts, function(err, str){
-      if (err) return done(err);
-      var body;
+  // raw-body returns a promise when no callback is specified
+  return raw(req, opts)
+    .then(function(str) {
       try {
-        body = parse(str);
+        return parse(str);
       } catch (err) {
         err.status = 400;
         err.body = str;
-        return done(err);
+        throw err;
       }
-      done(null, body);
     });
-  };
 
   function parse(str){
     if (!strict) return str ? JSON.parse(str) : str;

--- a/lib/text.js
+++ b/lib/text.js
@@ -5,7 +5,7 @@
 var raw = require('raw-body');
 
 /**
- * Return a a thunk which parses text/plain requests.
+ * Return a Promise which parses text/plain requests.
  *
  * Pass a node request or an object with `.req`,
  * such as a koa Context.
@@ -26,7 +26,6 @@ module.exports = function(req, opts){
   opts.encoding = opts.encoding || 'utf8';
   opts.limit = opts.limit || '1mb';
 
-  return function(done){
-    raw(req, opts,done);
-  };
+  // raw-body returns a Promise when no callback is specified
+  return raw(req, opts);
 };


### PR DESCRIPTION
This requires a global `Promise` object, which should be available in any environment that implements generators anyway.
Implementation is easy since `raw-body` already returns Promises when no callback is specified.
