### PR TITLE
fix: replace module qs with safe-qs, when param array length oversteps the limit will throw error

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -4,7 +4,7 @@
  */
 
 var raw = require('raw-body');
-var qs = require('qs');
+var qs = require('safe-qs');
 
 /**
  * Return a Promise which parses x-www-form-urlencoded requests.

--- a/lib/form.js
+++ b/lib/form.js
@@ -32,7 +32,7 @@ module.exports = function(req, opts){
   return raw(req, opts)
     .then(function(str){
       try {
-        return qs.parse(str, opts.queryString);
+        return (opts.qs || qs).parse(str, opts.queryString);
       } catch (err) {
         err.status = 400;
         err.body = str;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "urlencoded"
   ],
   "dependencies": {
-    "qs": "~4.0.0",
+    "safe-qs": "~6.0.1",
     "raw-body": "~2.1.2",
     "type-is": "~1.6.6"
   },


### PR DESCRIPTION
如题