### PR TITLE
add hook before parsing body

### DIFF
--- a/lib/json.js
+++ b/lib/json.js
@@ -31,11 +31,12 @@ module.exports = function(req, opts){
   opts.encoding = opts.encoding || 'utf8';
   opts.limit = opts.limit || '1mb';
   var strict = opts.strict !== false;
-
+  var onGottenRawBody = opts.onGottenRawBody||function(){};
   // raw-body returns a promise when no callback is specified
   return raw(req, opts)
     .then(function(str) {
       try {
+        onGottenRawBody(str);
         return parse(str);
       } catch (err) {
         err.status = 400;


### PR DESCRIPTION
add a hook function before parsing body, so the client can do something to the `raw str`, log it for example.