### PR TITLE
Add verify option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,6 +34,7 @@ $ npm install co-body
   - `jsonTypes` is used to determine what media type **co-body** will parse as **json**, this option is passed directly to the [type-is](https://github.com/jshttp/type-is) library.
   - `formTypes` is used to determine what media type **co-body** will parse as **form**, this option is passed directly to the [type-is](https://github.com/jshttp/type-is) library.
   - `textTypes` is used to determine what media type **co-body** will parse as **text**, this option is passed directly to the [type-is](https://github.com/jshttp/type-is) library.
+  - `verify` The verify option, if supplied, is called as verify(req, str), where `str` is a string of the raw request body. The parsing can be aborted by throwing an error.
 
 more options available via [raw-body](https://github.com/stream-utils/raw-body#getrawbodystream-options-callback):
 
@@ -57,6 +58,13 @@ var body = yield parse(req);
 
 // custom type
 var body = yield parse(req, { textTypes: ['text', 'html'] });
+
+// verify
+var body = yield parse(req, {
+  verify: function(req, str) {
+    req.rawBody = str;
+  }
+});
 ```
 
 ## Koa
@@ -76,6 +84,13 @@ var body = yield parse.text(this);
 
 // either
 var body = yield parse(this);
+
+// verify
+var body = yield parse(this, {
+  verify: function(req, str) {
+    req.rawBody = str;
+  }
+});
 ```
 
 # License

--- a/lib/form.js
+++ b/lib/form.js
@@ -33,7 +33,7 @@ module.exports = function(req, opts){
   var verify = opts.verify || false;
 
   if (verify !== false && typeof verify !== 'function') {
-    throw new TypeError('option verify must be function')
+    throw new TypeError('option verify must be function');
   }
 
   // raw-body returns a Promise when no callback is specified

--- a/lib/form.js
+++ b/lib/form.js
@@ -30,10 +30,25 @@ module.exports = function(req, opts){
   opts.encoding = opts.encoding || 'utf8';
   opts.limit = opts.limit || '56kb';
   opts.qs = opts.qs || qs;
+  var verify = opts.verify || false;
+
+  if (verify !== false && typeof verify !== 'function') {
+    throw new TypeError('option verify must be function')
+  }
 
   // raw-body returns a Promise when no callback is specified
   return raw(inflate(req), opts)
     .then(function(str){
+      try {
+        if (verify !== false) {
+          verify(req, str);
+        }
+      } catch (err) {
+        err.status = 403;
+        err.body = str;
+        throw err;
+      }
+
       try {
         return opts.qs.parse(str, opts.queryString);
       } catch (err) {

--- a/lib/json.js
+++ b/lib/json.js
@@ -36,7 +36,7 @@ module.exports = function(req, opts){
   var verify = opts.verify || false;
 
   if (verify !== false && typeof verify !== 'function') {
-    throw new TypeError('option verify must be function')
+    throw new TypeError('option verify must be function');
   }
 
   // raw-body returns a promise when no callback is specified

--- a/lib/json.js
+++ b/lib/json.js
@@ -33,10 +33,25 @@ module.exports = function(req, opts){
   opts.encoding = opts.encoding || 'utf8';
   opts.limit = opts.limit || '1mb';
   var strict = opts.strict !== false;
+  var verify = opts.verify || false;
+
+  if (verify !== false && typeof verify !== 'function') {
+    throw new TypeError('option verify must be function')
+  }
 
   // raw-body returns a promise when no callback is specified
   return raw(inflate(req), opts)
     .then(function(str) {
+      try {
+        if (verify !== false) {
+          verify(req, str);
+        }
+      } catch (err) {
+        err.status = 403;
+        err.body = str;
+        throw err;
+      }
+
       try {
         return parse(str);
       } catch (err) {

--- a/lib/text.js
+++ b/lib/text.js
@@ -30,7 +30,7 @@ module.exports = function(req, opts){
   var verify = opts.verify || false;
 
   if (verify !== false && typeof verify !== 'function') {
-    throw new TypeError('option verify must be function')
+    throw new TypeError('option verify must be function');
   }
 
   // raw-body returns a Promise when no callback is specified

--- a/lib/text.js
+++ b/lib/text.js
@@ -27,7 +27,25 @@ module.exports = function(req, opts){
   if (len && encoding === 'identity') opts.length = ~~len;
   opts.encoding = opts.encoding || 'utf8';
   opts.limit = opts.limit || '1mb';
+  var verify = opts.verify || false;
+
+  if (verify !== false && typeof verify !== 'function') {
+    throw new TypeError('option verify must be function')
+  }
 
   // raw-body returns a Promise when no callback is specified
-  return raw(inflate(req), opts);
+  return raw(inflate(req), opts)
+    .then(function(str){
+      try {
+        if (verify !== false) {
+          verify(req, str);
+        }
+      } catch (err) {
+        err.status = 403;
+        err.body = str;
+        throw err;
+      }
+
+      return str;
+    });
 };

--- a/test/text.js
+++ b/test/text.js
@@ -19,4 +19,51 @@ describe('parse.text(req, opts)', function(){
       .expect('Hello World!', done);
     });
   });
-});
+
+  describe('with verify', function(){
+    describe('and verify pass', function(){
+      it('should parse', function(done){
+        var app = koa();
+
+        app.use(function *(){
+          this.body = yield parse.text(this, {
+            verify: function(req, str) {
+              str.should.equal('Hello World!');
+            }
+          });
+        });
+
+        request(app.listen())
+        .post('/')
+        .send('Hello World!')
+        .expect(200)
+        .expect('Hello World!', done);
+      })
+    })
+
+    describe('and verify fail', function(){
+      it('should not parse', function(done){
+        var app = koa();
+
+        app.use(function *(){
+          try {
+            yield parse.text(this, {
+              verify: function(req, str) {
+                throw new Error('verify fail');
+              }
+            });
+          } catch(err) {
+            err.status.should.equal(403);
+            err.body.should.equal('Hello World!');
+            done();
+          }
+        });
+
+        request(app.listen())
+        .post('/')
+        .send('Hello World!')
+        .end(function(){});
+      });
+    })
+  })
+})


### PR DESCRIPTION
## Options

`verify` The verify option, if supplied, is called as verify(req, str), where `str` is a string of the raw request body. The parsing can be aborted by throwing an error.
## Example

``` js
// verify
var body = yield parse(req, {
  verify: function(req, str) {
    req.rawBody = str;
  }
});
```
## Koa

``` js
// verify
var body = yield parse(this, {
  verify: function(req, str) {
    req.rawBody = str;
  }
});
```
