### PR TITLE
fix: dont modify input options

### DIFF
--- a/lib/any.js
+++ b/lib/any.js
@@ -27,18 +27,17 @@ var textTypes = ['text'];
 
 module.exports = function(req, opts){
   req = req.req || req;
-  opts = opts || {};
 
   // json
-  var jsonType = opts.jsonTypes || jsonTypes;
+  var jsonType = opts && opts.jsonTypes || jsonTypes;
   if (typeis(req, jsonType)) return json(req, opts);
 
   // form
-  var formType = opts.formTypes || formTypes;
+  var formType = opts && opts.formTypes || formTypes;
   if (typeis(req, formType)) return form(req, opts);
 
   // text
-  var textType = opts.textTypes || textTypes;
+  var textType = opts && opts.textTypes || textTypes;
   if (typeis(req, textType)) return text(req, opts);
 
   // invalid

--- a/lib/form.js
+++ b/lib/form.js
@@ -3,6 +3,7 @@
  * Module dependencies.
  */
 
+var clone = require('clone');
 var raw = require('raw-body');
 var inflate = require('inflation');
 var qs = require('qs');
@@ -21,7 +22,7 @@ var qs = require('qs');
 
 module.exports = function(req, opts){
   req = req.req || req;
-  opts = opts || {};
+  opts = opts && clone(opts) || {};
 
   // defaults
   var len = req.headers['content-length'];

--- a/lib/json.js
+++ b/lib/json.js
@@ -3,6 +3,7 @@
  * Module dependencies.
  */
 
+var clone = require('clone');
 var raw = require('raw-body');
 var inflate = require('inflation');
 
@@ -24,7 +25,7 @@ var strictJSONReg = /^[\x20\x09\x0a\x0d]*(\[|\{)/;
 
 module.exports = function(req, opts){
   req = req.req || req;
-  opts = opts || {};
+  opts = opts && clone(opts) || {};
 
   // defaults
   var len = req.headers['content-length'];

--- a/lib/text.js
+++ b/lib/text.js
@@ -2,6 +2,7 @@
  * Module dependencies.
  */
 
+var clone = require('clone');
 var raw = require('raw-body');
 var inflate = require('inflation');
 
@@ -19,7 +20,7 @@ var inflate = require('inflation');
 
 module.exports = function(req, opts){
   req = req.req || req;
-  opts = opts || {};
+  opts = opts && clone(opts) || {};
 
   // defaults
   var len = req.headers['content-length'];

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "urlencoded"
   ],
   "dependencies": {
+    "clone": "^1.0.2",
+    "inflation": "~2.0.0",
     "qs": "~4.0.0",
     "raw-body": "~2.1.2",
-    "inflation": "~2.0.0",
     "type-is": "~1.6.6"
   },
   "devDependencies": {

--- a/test/form.js
+++ b/test/form.js
@@ -1,4 +1,5 @@
 
+var clone = require('clone');
 var request = require('supertest');
 var parse = require('..');
 var koa = require('koa');
@@ -19,6 +20,26 @@ describe('parse.form(req, opts)', function(){
       .type('form')
       .send({ foo: { bar: 'baz' }})
       .end(function(err){ done(err); });
+    })
+
+    it('should not modify input opts', function(done){
+      var app = koa();
+
+      app.on('error', done);
+
+      app.use(function *() {
+        var opts = {};
+        var optsCopy = clone(opts);
+        yield parse.form(this, opts);
+        opts.should.eql(optsCopy);
+        done();
+      });
+
+      request(app.listen())
+      .post('/')
+      .type('form')
+      .send({ foo: { bar: 'baz' } })
+      .end(function(){});
     })
   })
 

--- a/test/json.js
+++ b/test/json.js
@@ -1,4 +1,5 @@
 
+var clone = require('clone');
 var request = require('supertest');
 var parse = require('..');
 var koa = require('koa');
@@ -11,6 +12,25 @@ describe('parse.json(req, opts)', function(){
       app.use(function *(){
         var body = yield parse.json(this);
         body.should.eql({ foo: 'bar' });
+        done();
+      });
+
+      request(app.listen())
+      .post('/')
+      .send({ foo: 'bar' })
+      .end(function(){});
+    })
+
+    it('should not modify input opts', function(done){
+      var app = koa();
+
+      app.on('error', done);
+
+      app.use(function *() {
+        var opts = {};
+        var optsCopy = clone(opts);
+        yield parse.json(this, opts);
+        opts.should.eql(optsCopy);
         done();
       });
 

--- a/test/text.js
+++ b/test/text.js
@@ -1,4 +1,5 @@
 
+var clone = require('clone');
 var request = require('supertest');
 var parse = require('..');
 var koa = require('koa');
@@ -17,6 +18,25 @@ describe('parse.text(req, opts)', function(){
       .send('Hello World!')
       .expect(200)
       .expect('Hello World!', done);
+    });
+
+    it('should not modify input opts', function(done){
+      var app = koa();
+
+      app.on('error', done);
+
+      app.use(function *() {
+        var opts = {};
+        var optsCopy = clone(opts);
+        yield parse.text(this, opts);
+        opts.should.eql(optsCopy);
+        done();
+      });
+
+      request(app.listen())
+      .post('/')
+      .send('Hello World!')
+      .end(function(){});
     });
   });
 });


### PR DESCRIPTION
This was manifesting itself via usage of koa-bodyparser and a client
sending a gzipped body. opts.length would be set from an identity
call, which would cause a subsequent gzip call to fail
