### PR TITLE
fixes a bug that carries the content length from previous requests

### DIFF
--- a/lib/any.js
+++ b/lib/any.js
@@ -28,23 +28,18 @@ var textTypes = ['text'];
 module.exports = function(req, opts){
   req = req.req || req;
   opts = opts || {};
-  var options = {
-    encoding: opts.encoding,
-    limit: opts.limit,
-    length: opts.length
-  };
 
   // json
   var jsonType = opts.jsonTypes || jsonTypes;
-  if (typeis(req, jsonType)) return json(req, options);
+  if (typeis(req, jsonType)) return json(req, opts);
 
   // form
   var formType = opts.formTypes || formTypes;
-  if (typeis(req, formType)) return form(req, options);
+  if (typeis(req, formType)) return form(req, opts);
 
   // text
   var textType = opts.textTypes || textTypes;
-  if (typeis(req, textType)) return text(req, options);
+  if (typeis(req, textType)) return text(req, opts);
 
   // invalid
   var type = req.headers['content-type'] || '';

--- a/lib/any.js
+++ b/lib/any.js
@@ -28,18 +28,23 @@ var textTypes = ['text'];
 module.exports = function(req, opts){
   req = req.req || req;
   opts = opts || {};
+  var options = {
+    encoding: opts.encoding,
+    limit: opts.limit,
+    length: opts.length
+  };
 
   // json
   var jsonType = opts.jsonTypes || jsonTypes;
-  if (typeis(req, jsonType)) return json(req, opts);
+  if (typeis(req, jsonType)) return json(req, options);
 
   // form
   var formType = opts.formTypes || formTypes;
-  if (typeis(req, formType)) return form(req, opts);
+  if (typeis(req, formType)) return form(req, options);
 
   // text
   var textType = opts.textTypes || textTypes;
-  if (typeis(req, textType)) return text(req, opts);
+  if (typeis(req, textType)) return text(req, options);
 
   // invalid
   var type = req.headers['content-type'] || '';

--- a/lib/form.js
+++ b/lib/form.js
@@ -14,7 +14,7 @@ var qs = require('qs');
  * such as a koa Context.
  *
  * @param {Request} req
- * @param {Options} [opts]
+ * @param {Options} [options]
  * @return {Function}
  * @api public
  */
@@ -22,20 +22,28 @@ var qs = require('qs');
 module.exports = function(req, opts){
   req = req.req || req;
   opts = opts || {};
+  var options = {
+    encoding: opts.encoding,
+    limit: opts.limit,
+    length: opts.length,
+    strict: opts.strict,
+    queryString: opts.queryString
+  };
+
 
   // defaults
   var len = req.headers['content-length'];
   var encoding = req.headers['content-encoding'] || 'identity';
-  if (len && encoding === 'identity') opts.length = ~~len;
-  opts.encoding = opts.encoding || 'utf8';
-  opts.limit = opts.limit || '56kb';
-  opts.qs = opts.qs || qs;
+  if (len && encoding === 'identity') options.length = ~~len;
+  options.encoding = options.encoding || 'utf8';
+  options.limit = options.limit || '56kb';
+  options.qs = opts.qs || qs;
 
   // raw-body returns a Promise when no callback is specified
-  return raw(inflate(req), opts)
+  return raw(inflate(req), options)
     .then(function(str){
       try {
-        return opts.qs.parse(str, opts.queryString);
+        return options.qs.parse(str, options.queryString);
       } catch (err) {
         err.status = 400;
         err.body = str;

--- a/lib/json.js
+++ b/lib/json.js
@@ -17,7 +17,7 @@ var strictJSONReg = /^[\x20\x09\x0a\x0d]*(\[|\{)/;
  * such as a koa Context.
  *
  * @param {Request} req
- * @param {Options} [opts]
+ * @param {Options} [options]
  * @return {Function}
  * @api public
  */
@@ -25,17 +25,26 @@ var strictJSONReg = /^[\x20\x09\x0a\x0d]*(\[|\{)/;
 module.exports = function(req, opts){
   req = req.req || req;
   opts = opts || {};
+  opts = opts || {};
+  var options = {
+    encoding: opts.encoding,
+    limit: opts.limit,
+    length: opts.length,
+    strict: opts.strict,
+    queryString: opts.queryString
+  };
+
 
   // defaults
   var len = req.headers['content-length'];
   var encoding = req.headers['content-encoding'] || 'identity';
-  if (len && encoding === 'identity') opts.length = len = ~~len;
-  opts.encoding = opts.encoding || 'utf8';
-  opts.limit = opts.limit || '1mb';
-  var strict = opts.strict !== false;
+  if (len && encoding === 'identity') options.length = len = ~~len;
+  options.encoding = options.encoding || 'utf8';
+  options.limit = options.limit || '1mb';
+  var strict = options.strict !== false;
 
   // raw-body returns a promise when no callback is specified
-  return raw(inflate(req), opts)
+  return raw(inflate(req), options)
     .then(function(str) {
       try {
         return parse(str);

--- a/lib/text.js
+++ b/lib/text.js
@@ -20,7 +20,6 @@ var inflate = require('inflation');
 module.exports = function(req, opts){
   req = req.req || req;
   opts = opts || {};
-  opts = opts || {};
   var options = {
     encoding: opts.encoding,
     limit: opts.limit,

--- a/lib/text.js
+++ b/lib/text.js
@@ -12,7 +12,7 @@ var inflate = require('inflation');
  * such as a koa Context.
  *
  * @param {Request} req
- * @param {Options} [opts]
+ * @param {Options} [options]
  * @return {Function}
  * @api public
  */
@@ -20,14 +20,23 @@ var inflate = require('inflation');
 module.exports = function(req, opts){
   req = req.req || req;
   opts = opts || {};
+  opts = opts || {};
+  var options = {
+    encoding: opts.encoding,
+    limit: opts.limit,
+    length: opts.length,
+    strict: opts.strict,
+    queryString: opts.queryString
+  };
+
 
   // defaults
   var len = req.headers['content-length'];
   var encoding = req.headers['content-encoding'] || 'identity';
-  if (len && encoding === 'identity') opts.length = ~~len;
-  opts.encoding = opts.encoding || 'utf8';
-  opts.limit = opts.limit || '1mb';
+  if (len && encoding === 'identity') options.length = ~~len;
+  options.encoding = options.encoding || 'utf8';
+  options.limit = options.limit || '1mb';
 
   // raw-body returns a Promise when no callback is specified
-  return raw(inflate(req), opts);
+  return raw(inflate(req), options);
 };

--- a/test/any.js
+++ b/test/any.js
@@ -189,7 +189,6 @@ describe('parse(req, opts)', function(){
       var app = koa();
       var options = {};
       app.use(function *(){
-        console.log(options);
         this.body = yield parse(this, options);
       });
 

--- a/test/any.js
+++ b/test/any.js
@@ -184,6 +184,35 @@ describe('parse(req, opts)', function(){
       req.write(zlib.deflateSync(json));
       req.end(function(){});
     })
+
+    describe("after indentity and with shared options", function () {
+      var app = koa();
+      var options = {};
+      app.use(function *(){
+        console.log(options);
+        this.body = yield parse(this, options);
+      });
+
+      before(function(done) {
+        request(app.listen())
+            .post('/')
+            .set('Content-Encoding', 'identity')
+            .send({ foo: 'bar', and: 'something extra' })
+            .expect(200, done);
+      });
+      it('should inflate deflate', function(done){
+
+        var json = JSON.stringify({ foo: 'bar' });
+
+        var req = request(app.listen())
+            .post('/')
+            .type('json')
+            .set('Content-Encoding', 'deflate');
+        req.write(zlib.deflateSync(json));
+        req.expect(200, done);
+      })
+    });
+
     it('should pass-through identity', function(done){
       var app = koa();
 


### PR DESCRIPTION
Related to #44 .
#### Bug description

When mixed compressed and uncompressed requests happen and the caller is using a shared options object (like koa-bodyparser does), then the length of the previous request is carried to the next request giving the following error:

```
Error: request size did not match content length
      at Unzip.onEnd (./koa-bodyparser/node_modules/co-body/node_modules/raw-body/index.js:298:12)
      at emitNone (events.js:72:20)
      at Unzip.emit (events.js:166:7)
      at endReadableNT (_stream_readable.js:905:12)
      at nextTickCallbackWith2Args (node.js:437:9)
      at process._tickCallback (node.js:351:17)
```

See the test added to reproduce it.
#### Fix
- This PR fixes it for all content-type, not only 'form' (as PR #44 does)
- This PR doesn't use expensive deep copy because raw-body is only using the following options 

```
{
    encoding: opts.encoding,
    limit: opts.limit,
    length: opts.length
}
```
