### PR TITLE
fix: allow multiple body parser coexist

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -37,10 +37,7 @@ module.exports = function(req, opts){
   opts.qs = opts.qs || qs;
 
   // raw-body returns a Promise when no callback is specified
-  return Promise.resolve()
-    .then(function() {
-      return raw(inflate(req), opts);
-    })
+  return raw(inflate(req), opts)
     .then(function(str){
       try {
         var parsed = opts.qs.parse(str, queryString);

--- a/lib/json.js
+++ b/lib/json.js
@@ -36,10 +36,7 @@ module.exports = function(req, opts){
   var strict = opts.strict !== false;
 
   // raw-body returns a promise when no callback is specified
-  return Promise.resolve()
-    .then(function() {
-      return raw(inflate(req), opts);
-    })
+  return raw(inflate(req), opts)
     .then(function(str) {
       try {
         var parsed = parse(str);

--- a/lib/text.js
+++ b/lib/text.js
@@ -30,10 +30,7 @@ module.exports = function(req, opts){
   opts.limit = opts.limit || '1mb';
 
   // raw-body returns a Promise when no callback is specified
-  return Promise.resolve()
-    .then(function() {
-      return raw(inflate(req), opts);
-    })
+  return raw(inflate(req), opts)
     .then(str => {
       // ensure return the same format with json / form
       return opts.returnRawBody ? { parsed: str, raw: str } : str;


### PR DESCRIPTION
by sync listen events on ctx.req, multiple body parser coexist is safe.

json parser's returnRawBody option can provide untouched request body,
we can use it to do signature validation if required,
but co-body commonly use by high level middlewares,
and not expose a option for user to customize.

allow multiple body parser coexist is a more elegant solution.