### PR TITLE
Adds custom error class for easier error differentiation

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,3 +4,4 @@ exports = module.exports = require('./lib/any');
 exports.json = require('./lib/json');
 exports.form = require('./lib/form');
 exports.text = require('./lib/text');
+exports.CoBodyError = require('./lib/utils').CoBodyError;

--- a/lib/any.js
+++ b/lib/any.js
@@ -5,6 +5,7 @@
  */
 
 const typeis = require('type-is');
+const utils = require('./utils');
 const json = require('./json');
 const form = require('./form');
 const text = require('./text');
@@ -45,7 +46,7 @@ module.exports = async function(req, opts) {
   // invalid
   const type = req.headers['content-type'] || '';
   const message = type ? 'Unsupported content-type: ' + type : 'Missing content-type';
-  const err = new Error(message);
+  const err = new utils.CoBodyError(message);
   err.status = 415;
   throw err;
 };

--- a/lib/form.js
+++ b/lib/form.js
@@ -42,8 +42,9 @@ module.exports = async function(req, opts) {
     const parsed = opts.qs.parse(str, queryString);
     return opts.returnRawBody ? { parsed, raw: str } : parsed;
   } catch (err) {
-    err.status = 400;
-    err.body = str;
-    throw err;
+    const error = utils.CoBodyError(err.message);
+    error.status = 400;
+    error.body = str;
+    throw error;
   }
 };

--- a/lib/json.js
+++ b/lib/json.js
@@ -41,9 +41,10 @@ module.exports = async function(req, opts) {
     const parsed = parse(str);
     return opts.returnRawBody ? { parsed, raw: str } : parsed;
   } catch (err) {
-    err.status = 400;
-    err.body = str;
-    throw err;
+    const error = utils.CoBodyError(err.message);
+    error.status = 400;
+    error.body = str;
+    throw error;
   }
 
   function parse(str) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,3 +12,11 @@ exports.clone = function(opts) {
   }
   return options;
 };
+
+exports.CoBodyError = class CoBodyError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = this.constructor.name;
+    Error.captureStackTrace(this, this.constructor);
+  }
+};


### PR DESCRIPTION
As the title says, throw a custom error and export the error class for easier error testing/handling.