### PR TITLE
Throw one type error for json (strict = true)

### DIFF
--- a/lib/json.js
+++ b/lib/json.js
@@ -52,7 +52,7 @@ module.exports = async function(req, opts) {
     if (!str) return {};
     // strict JSON test
     if (!strictJSONReg.test(str)) {
-      throw new Error('invalid JSON, only supports object and array');
+      throw new SyntaxError('invalid JSON, only supports object and array');
     }
     return JSON.parse(str);
   }

--- a/test/json.test.js
+++ b/test/json.test.js
@@ -83,6 +83,7 @@ describe('parse.json(req, opts)', function() {
         try {
           yield parse.json(this);
         } catch (err) {
+          err.should.be.an.instanceOf(SyntaxError);
           err.status.should.equal(400);
           err.body.should.equal('{"foo": "bar');
           done();
@@ -124,6 +125,7 @@ describe('parse.json(req, opts)', function() {
           try {
             yield parse.json(this, { strict: true });
           } catch (err) {
+            err.should.be.an.instanceOf(SyntaxError);
             err.status.should.equal(400);
             err.body.should.equal('"foo"');
             err.message.should.equal('invalid JSON, only supports object and array');


### PR DESCRIPTION
# Scope
In Json strict mode there are 2 types of error:
 - caused by first character validation: Error
 - caused by JSON.parse: SyntaxError

To simplify error handling I propose throw SyntaxError for first case too.