### PR TITLE
Add a parameter named transformBody to parse the request body in a user-defined way

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -31,6 +31,7 @@ $ npm install co-body
   - `strict` when set to `true`, JSON parser will only accept arrays and objects; when `false` will accept anything `JSON.parse` accepts. Defaults to `true`. (also `strict` mode will always return object).
   - `queryString` an object of options when parsing query strings and form data. See [qs](https://github.com/hapijs/qs) for more information.
   - `returnRawBody` when set to `true`, the return value of `co-body` will be an object with two properties: `{ parsed: /* parsed value */, raw: /* raw body */}`.
+  - `transformBody` when set to a function, bodyparse will use this function to parse request body instead of default parse modules.
   - `jsonTypes` is used to determine what media type **co-body** will parse as **json**, this option is passed directly to the [type-is](https://github.com/jshttp/type-is) library.
   - `formTypes` is used to determine what media type **co-body** will parse as **form**, this option is passed directly to the [type-is](https://github.com/jshttp/type-is) library.
   - `textTypes` is used to determine what media type **co-body** will parse as **text**, this option is passed directly to the [type-is](https://github.com/jshttp/type-is) library.
@@ -57,6 +58,13 @@ var body = await parse(req);
 
 // custom type
 var body = await parse(req, { textTypes: ['text', 'html'] });
+
+// transformBody
+var body = await parse(req, {
+  transformBody: function(reqBodyStr) {
+    return JSON.parse(reqBodyStr);
+  }
+})
 ```
 
 ## Koa

--- a/lib/form.js
+++ b/lib/form.js
@@ -21,7 +21,7 @@ const utils = require('./utils');
  * @api public
  */
 
-module.exports = async function(req, opts) {
+module.exports = async function (req, opts) {
   req = req.req || req;
   opts = utils.clone(opts);
   const queryString = opts.queryString || {};
@@ -36,10 +36,15 @@ module.exports = async function(req, opts) {
   opts.encoding = opts.encoding || 'utf8';
   opts.limit = opts.limit || '56kb';
   opts.qs = opts.qs || qs;
-
+  opts.transformBody = opts.transformBody || null;
   const str = await raw(inflate(req), opts);
   try {
-    const parsed = opts.qs.parse(str, queryString);
+    let parsed;
+    if (opts.transformBody && opts.transformBody instanceof Function) {
+      parsed = opts.transformBody(str);
+    } else {
+      parsed = opts.qs.parse(str, queryString);
+    }
     return opts.returnRawBody ? { parsed, raw: str } : parsed;
   } catch (err) {
     err.status = 400;

--- a/lib/form.js
+++ b/lib/form.js
@@ -21,7 +21,7 @@ const utils = require('./utils');
  * @api public
  */
 
-module.exports = async function (req, opts) {
+module.exports = async function(req, opts) {
   req = req.req || req;
   opts = utils.clone(opts);
   const queryString = opts.queryString || {};
@@ -37,10 +37,12 @@ module.exports = async function (req, opts) {
   opts.limit = opts.limit || '56kb';
   opts.qs = opts.qs || qs;
   opts.transformBody = opts.transformBody || null;
+
   const str = await raw(inflate(req), opts);
   try {
     let parsed;
     if (opts.transformBody && opts.transformBody instanceof Function) {
+      //use transformBody to parse request body
       parsed = opts.transformBody(str);
     } else {
       parsed = opts.qs.parse(str, queryString);

--- a/lib/form.js
+++ b/lib/form.js
@@ -42,7 +42,7 @@ module.exports = async function(req, opts) {
   try {
     let parsed;
     if (opts.transformBody && opts.transformBody instanceof Function) {
-      //use transformBody to parse request body
+      // use transformBody to parse request body
       parsed = opts.transformBody(str);
     } else {
       parsed = opts.qs.parse(str, queryString);

--- a/lib/json.js
+++ b/lib/json.js
@@ -24,7 +24,7 @@ const strictJSONReg = /^[\x20\x09\x0a\x0d]*(\[|\{)/;
  * @api public
  */
 
-module.exports = async function(req, opts) {
+module.exports = async function (req, opts) {
   req = req.req || req;
   opts = utils.clone(opts);
 
@@ -34,11 +34,19 @@ module.exports = async function(req, opts) {
   if (len && encoding === 'identity') opts.length = ~~len;
   opts.encoding = opts.encoding || 'utf8';
   opts.limit = opts.limit || '1mb';
+  opts.transformBody = opts.transformBody || null;
   const strict = opts.strict !== false;
 
   const str = await raw(inflate(req), opts);
   try {
-    const parsed = parse(str);
+    let parsed;
+    if (opts.transformBody && opts.transformBody instanceof Function) {
+      console.log('transformBody')
+      const transformBody = opts.transformBody;
+      parsed = transformBody(str);
+    } else {
+      parsed = parse(str);
+    }
     return opts.returnRawBody ? { parsed, raw: str } : parsed;
   } catch (err) {
     err.status = 400;

--- a/lib/json.js
+++ b/lib/json.js
@@ -24,7 +24,7 @@ const strictJSONReg = /^[\x20\x09\x0a\x0d]*(\[|\{)/;
  * @api public
  */
 
-module.exports = async function (req, opts) {
+module.exports = async function(req, opts) {
   req = req.req || req;
   opts = utils.clone(opts);
 
@@ -41,7 +41,7 @@ module.exports = async function (req, opts) {
   try {
     let parsed;
     if (opts.transformBody && opts.transformBody instanceof Function) {
-      console.log('transformBody')
+      //use transformBody to parse request body
       const transformBody = opts.transformBody;
       parsed = transformBody(str);
     } else {

--- a/lib/json.js
+++ b/lib/json.js
@@ -41,7 +41,7 @@ module.exports = async function(req, opts) {
   try {
     let parsed;
     if (opts.transformBody && opts.transformBody instanceof Function) {
-      //use transformBody to parse request body
+      // use transformBody to parse request body
       const transformBody = opts.transformBody;
       parsed = transformBody(str);
     } else {

--- a/lib/text.js
+++ b/lib/text.js
@@ -30,8 +30,13 @@ module.exports = async function(req, opts) {
   if (len && encoding === 'identity') opts.length = ~~len;
   opts.encoding = opts.encoding === undefined ? 'utf8' : opts.encoding;
   opts.limit = opts.limit || '1mb';
+  opts.transformBody = opts.transformBody || null;
 
   const str = await raw(inflate(req), opts);
+  if(opts.transformBody && opts.transformBody instanceof Function) {
+    const transformStr = opts.transformBody(str);
+    return opts.returnRawBody ? { parsed: transformStr, raw: str } : transformStr;
+  }
   // ensure return the same format with json / form
   return opts.returnRawBody ? { parsed: str, raw: str } : str;
 };

--- a/lib/text.js
+++ b/lib/text.js
@@ -33,8 +33,8 @@ module.exports = async function(req, opts) {
   opts.transformBody = opts.transformBody || null;
 
   const str = await raw(inflate(req), opts);
-  if(opts.transformBody && opts.transformBody instanceof Function) {
-    //use transformBody to parse request body
+  if (opts.transformBody && opts.transformBody instanceof Function) {
+    // use transformBody to parse request body
     const transformStr = opts.transformBody(str);
     return opts.returnRawBody ? { parsed: transformStr, raw: str } : transformStr;
   }

--- a/lib/text.js
+++ b/lib/text.js
@@ -34,6 +34,7 @@ module.exports = async function(req, opts) {
 
   const str = await raw(inflate(req), opts);
   if(opts.transformBody && opts.transformBody instanceof Function) {
+    //use transformBody to parse request body
     const transformStr = opts.transformBody(str);
     return opts.returnRawBody ? { parsed: transformStr, raw: str } : transformStr;
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "koa": "^1.6.0",
     "safe-qs": "^6.0.1",
     "should": "^11.2.0",
-    "supertest": "^3.1.0"
+    "supertest": "^3.1.0",
+    "json-bigint": "^1.0.0"
   },
   "license": "MIT",
   "scripts": {

--- a/test/form.test.js
+++ b/test/form.test.js
@@ -152,4 +152,25 @@ describe('parse.form(req, opts)', function() {
         .expect(200, done);
     });
   });
+  describe('transformBody', function() {
+    it('should return transform request body result when opts.transformBody is a function', function(done) {
+      const app = koa();
+
+      app.use(function* () {
+        this.body = yield parse.form(this, {
+          transformBody: function(str) {
+            const qs = require('qs');
+            return qs.parse(str, { allowDots: true });
+          }
+        });
+      });
+
+      request(app.callback())
+        .post('/')
+        .type('form')
+        .send('a.b=1&a.c=2')
+        .expect({ a: { b: '1', c: '2' } })
+        .expect(200, done);
+    });
+  });
 });

--- a/test/form.test.js
+++ b/test/form.test.js
@@ -157,11 +157,12 @@ describe('parse.form(req, opts)', function() {
       const app = koa();
 
       app.use(function* () {
+        const transformBodyFunc = function(str) {
+          const qs = require('qs');
+          return qs.parse(str, { allowDots: true });
+        };
         this.body = yield parse.form(this, {
-          transformBody: function(str) {
-            const qs = require('qs');
-            return qs.parse(str, { allowDots: true });
-          }
+          transformBody: transformBodyFunc,
         });
       });
 

--- a/test/json.test.js
+++ b/test/json.test.js
@@ -3,10 +3,11 @@
 const request = require('supertest');
 const parse = require('..');
 const koa = require('koa');
+var JSONbig = require('json-bigint');
 
-describe('parse.json(req, opts)', function() {
-  describe('with valid json', function() {
-    it('should parse', function(done) {
+describe('parse.json(req, opts)', function () {
+  describe('with valid json', function () {
+    it('should parse', function (done) {
       const app = koa();
 
       app.use(function* () {
@@ -18,12 +19,12 @@ describe('parse.json(req, opts)', function() {
       request(app.callback())
         .post('/')
         .send({ foo: 'bar' })
-        .end(function() {});
+        .end(function () { });
     });
   });
 
-  describe('with invalid content encoding', function() {
-    it('should throw 415', function(done) {
+  describe('with invalid content encoding', function () {
+    it('should throw 415', function (done) {
       const app = koa();
 
       app.use(function* () {
@@ -41,9 +42,9 @@ describe('parse.json(req, opts)', function() {
     });
   });
 
-  describe('with content-length zero', function() {
-    describe('and strict === false', function() {
-      it('should return null', function(done) {
+  describe('with content-length zero', function () {
+    describe('and strict === false', function () {
+      it('should return null', function (done) {
         const app = koa();
 
         app.use(function* () {
@@ -54,12 +55,12 @@ describe('parse.json(req, opts)', function() {
         request(app.callback())
           .post('/')
           .set('content-length', 0)
-          .end(function() {});
+          .end(function () { });
       });
     });
 
-    describe('and strict === true', function() {
-      it('should return null', function(done) {
+    describe('and strict === true', function () {
+      it('should return null', function (done) {
         const app = koa();
 
         app.use(function* () {
@@ -70,13 +71,13 @@ describe('parse.json(req, opts)', function() {
         request(app.callback())
           .post('/')
           .set('content-length', 0)
-          .end(function() {});
+          .end(function () { });
       });
     });
   });
 
-  describe('with invalid json', function() {
-    it('should parse error', function(done) {
+  describe('with invalid json', function () {
+    it('should parse error', function (done) {
       const app = koa();
 
       app.use(function* () {
@@ -93,13 +94,13 @@ describe('parse.json(req, opts)', function() {
         .post('/')
         .set('content-type', 'application/json')
         .send('{"foo": "bar')
-        .end(function() {});
+        .end(function () { });
     });
   });
 
-  describe('with non-object json', function() {
-    describe('and strict === false', function() {
-      it('should parse', function(done) {
+  describe('with non-object json', function () {
+    describe('and strict === false', function () {
+      it('should parse', function (done) {
         const app = koa();
 
         app.use(function* () {
@@ -112,12 +113,12 @@ describe('parse.json(req, opts)', function() {
           .post('/')
           .set('content-type', 'application/json')
           .send('"foo"')
-          .end(function() {});
+          .end(function () { });
       });
     });
 
-    describe('and strict === true', function() {
-      it('should parse', function(done) {
+    describe('and strict === true', function () {
+      it('should parse', function (done) {
         const app = koa();
 
         app.use(function* () {
@@ -135,13 +136,13 @@ describe('parse.json(req, opts)', function() {
           .post('/')
           .set('content-type', 'application/json')
           .send('"foo"')
-          .end(function() {});
+          .end(function () { });
       });
     });
   });
 
-  describe('returnRawBody', function() {
-    it('should return raw body when opts.returnRawBody = true', function(done) {
+  describe('returnRawBody', function () {
+    it('should return raw body when opts.returnRawBody = true', function (done) {
       const app = koa();
 
       app.use(function* () {
@@ -153,6 +154,26 @@ describe('parse.json(req, opts)', function() {
         .type('json')
         .send({ foo: 'bar' })
         .expect({ parsed: { foo: 'bar' }, raw: '{"foo":"bar"}' })
+        .expect(200, done);
+    });
+  });
+
+  describe('transformBody', function () {
+    it('should return transform request body result when opts.transformBody is a function', function (done) {
+      const app = koa();
+      app.use(function* () {
+        const parsed = yield parse.json(this, {
+          transformBody: function (str) {
+            return JSONbig.parse(str);
+          }
+        });
+        this.body = parsed.id.toString();
+      });
+      request(app.callback())
+        .post('/')
+        .type('json')
+        .send('{ "id": 9223372036854775807 }')
+        .expect("9223372036854775807")
         .expect(200, done);
     });
   });

--- a/test/json.test.js
+++ b/test/json.test.js
@@ -3,11 +3,11 @@
 const request = require('supertest');
 const parse = require('..');
 const koa = require('koa');
-var JSONbig = require('json-bigint');
+const JSONbig = require('json-bigint');
 
-describe('parse.json(req, opts)', function () {
-  describe('with valid json', function () {
-    it('should parse', function (done) {
+describe('parse.json(req, opts)', function() {
+  describe('with valid json', function() {
+    it('should parse', function(done) {
       const app = koa();
 
       app.use(function* () {
@@ -19,12 +19,12 @@ describe('parse.json(req, opts)', function () {
       request(app.callback())
         .post('/')
         .send({ foo: 'bar' })
-        .end(function () { });
+        .end(function() { });
     });
   });
 
-  describe('with invalid content encoding', function () {
-    it('should throw 415', function (done) {
+  describe('with invalid content encoding', function() {
+    it('should throw 415', function(done) {
       const app = koa();
 
       app.use(function* () {
@@ -42,9 +42,9 @@ describe('parse.json(req, opts)', function () {
     });
   });
 
-  describe('with content-length zero', function () {
-    describe('and strict === false', function () {
-      it('should return null', function (done) {
+  describe('with content-length zero', function() {
+    describe('and strict === false', function() {
+      it('should return null', function(done) {
         const app = koa();
 
         app.use(function* () {
@@ -55,12 +55,12 @@ describe('parse.json(req, opts)', function () {
         request(app.callback())
           .post('/')
           .set('content-length', 0)
-          .end(function () { });
+          .end(function() { });
       });
     });
 
-    describe('and strict === true', function () {
-      it('should return null', function (done) {
+    describe('and strict === true', function() {
+      it('should return null', function(done) {
         const app = koa();
 
         app.use(function* () {
@@ -71,13 +71,13 @@ describe('parse.json(req, opts)', function () {
         request(app.callback())
           .post('/')
           .set('content-length', 0)
-          .end(function () { });
+          .end(function() { });
       });
     });
   });
 
-  describe('with invalid json', function () {
-    it('should parse error', function (done) {
+  describe('with invalid json', function() {
+    it('should parse error', function(done) {
       const app = koa();
 
       app.use(function* () {
@@ -94,13 +94,13 @@ describe('parse.json(req, opts)', function () {
         .post('/')
         .set('content-type', 'application/json')
         .send('{"foo": "bar')
-        .end(function () { });
+        .end(function() { });
     });
   });
 
-  describe('with non-object json', function () {
-    describe('and strict === false', function () {
-      it('should parse', function (done) {
+  describe('with non-object json', function() {
+    describe('and strict === false', function() {
+      it('should parse', function(done) {
         const app = koa();
 
         app.use(function* () {
@@ -113,12 +113,12 @@ describe('parse.json(req, opts)', function () {
           .post('/')
           .set('content-type', 'application/json')
           .send('"foo"')
-          .end(function () { });
+          .end(function() { });
       });
     });
 
-    describe('and strict === true', function () {
-      it('should parse', function (done) {
+    describe('and strict === true', function() {
+      it('should parse', function(done) {
         const app = koa();
 
         app.use(function* () {
@@ -136,13 +136,13 @@ describe('parse.json(req, opts)', function () {
           .post('/')
           .set('content-type', 'application/json')
           .send('"foo"')
-          .end(function () { });
+          .end(function() { });
       });
     });
   });
 
-  describe('returnRawBody', function () {
-    it('should return raw body when opts.returnRawBody = true', function (done) {
+  describe('returnRawBody', function() {
+    it('should return raw body when opts.returnRawBody = true', function(done) {
       const app = koa();
 
       app.use(function* () {
@@ -158,14 +158,15 @@ describe('parse.json(req, opts)', function () {
     });
   });
 
-  describe('transformBody', function () {
-    it('should return transform request body result when opts.transformBody is a function', function (done) {
+  describe('transformBody', function() {
+    it('should return transform request body result when opts.transformBody is a function', function(done) {
       const app = koa();
       app.use(function* () {
+        const transformBodyFunc = function(str) {
+          return JSONbig.parse(str);
+        };
         const parsed = yield parse.json(this, {
-          transformBody: function (str) {
-            return JSONbig.parse(str);
-          }
+          transformBody: transformBodyFunc,
         });
         this.body = parsed.id.toString();
       });
@@ -173,7 +174,7 @@ describe('parse.json(req, opts)', function () {
         .post('/')
         .type('json')
         .send('{ "id": 9223372036854775807 }')
-        .expect("9223372036854775807")
+        .expect('9223372036854775807')
         .expect(200, done);
     });
   });

--- a/test/text.test.js
+++ b/test/text.test.js
@@ -76,10 +76,11 @@ describe('parse.text(req, opts)', function() {
       const app = koa();
 
       app.use(function* () {
-        const requestBody = yield parse.text(this, { 
-          transformBody: function(str) {
-            return str + ' World!';
-          }
+        const transfomBodyFunc = function(str) {
+          return str + ' World!';
+        };
+        const requestBody = yield parse.text(this, {
+          transformBody: transfomBodyFunc,
         });
         this.body = requestBody;
       });
@@ -87,7 +88,7 @@ describe('parse.text(req, opts)', function() {
       request(app.callback())
         .post('/')
         .send('Hello')
-        .expect("Hello World!")
+        .expect('Hello World!')
         .expect(200, done);
     });
   });

--- a/test/text.test.js
+++ b/test/text.test.js
@@ -71,4 +71,24 @@ describe('parse.text(req, opts)', function() {
         .expect(200, done);
     });
   });
+  describe('transformBody', function() {
+    it('should return transform request body result when opts.transformBody is a function', function(done) {
+      const app = koa();
+
+      app.use(function* () {
+        const requestBody = yield parse.text(this, { 
+          transformBody: function(str) {
+            return str + ' World!';
+          }
+        });
+        this.body = requestBody;
+      });
+
+      request(app.callback())
+        .post('/')
+        .send('Hello')
+        .expect("Hello World!")
+        .expect(200, done);
+    });
+  });
 });


### PR DESCRIPTION
Add a parameter named transformBody to parse the request body in a user-defined way. For example,
```
//opts
const opts = {
    transformBody: function(str) {
        const JsonBigInt = require("json-bigint");
        return JsonBigInt.parse(str);
    }
}
```